### PR TITLE
Updated discard method

### DIFF
--- a/api/card.js
+++ b/api/card.js
@@ -38,13 +38,15 @@ let cards = {
                     console.error(`${card.name} is ALREADY discarded!`);
                     return;
                 }
-                this.discardPile.push(this.deck.shift());
+                let index = this.deck.indexOf(card);
+                this.discardPile.push(this.deck.splice(index, 1));
             } else {
                 console.error(`${card.name} is NOT in play!`);
                 return;
             }
         }
-        this.discardPile.push(this.inPlay.shift());
+        let index = this.inPlay.indexOf(card);
+        this.discardPile.push(this.inPlay.splice(index, 1));
     },
     findCard(id){
         return this.list.find(card => card.id === id);


### PR DESCRIPTION
Updated `discard()` method to actually account for the `card` parameter passed in as an argument instead of just discarding the first item in the array (with `.shift()`).